### PR TITLE
Fixed invalid uri in playlistgenerator.go

### DIFF
--- a/mpdfavd/playlistgenerator.go
+++ b/mpdfavd/playlistgenerator.go
@@ -40,7 +40,7 @@ func generatePlaylist(mpdc *MPDClient, stickerName string, playlistName string, 
 	if err != nil {
 		log.Panic(err)
 	}
-	songStickers, err := mpdc.StickerFind(StickerSongType, "/", stickerName)
+	songStickers, err := mpdc.StickerFind(StickerSongType, "", stickerName)
 	if err != nil {
 		log.Panic(err)
 	}


### PR DESCRIPTION
see bugs.musicpd.org/view.php?id=4177#c9010
Until it isn't fixed, songStickers.size == 0 and there is nothing to write in .m3u
